### PR TITLE
Allow the Auto TOC maxdepth to be configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ See https://github.com/rtfd/recommonmark/blob/master/docs/conf.py for a full exa
 AutoStructify comes with the following options. See [http://recommonmark.readthedocs.org/en/latest/auto_structify.html](http://recommonmark.readthedocs.org/en/latest/auto_structify.html) for more information about the specific features.
 
 * __enable_auto_toc_tree__: enable the Auto Toc Tree feature.
+* __auto_toc_maxdepth__: The max depth of the Auto Toc. Defaults to 1.
 * __auto_toc_tree_section__: when True, Auto Toc Tree will only be enabled on section that matches the title.
 * __enable_auto_doc_ref__: enable the Auto Doc Ref feature. **Deprecated**
 * __enable_math__: enable the Math Formula feature.

--- a/recommonmark/transform.py
+++ b/recommonmark/transform.py
@@ -41,6 +41,7 @@ class AutoStructify(transforms.Transform):
 
     default_config = {
         'enable_auto_doc_ref': False,
+        'auto_toc_maxdepth': 1,
         'auto_toc_tree_section': None,
         'enable_auto_toc_tree': True,
         'enable_eval_rst': True,
@@ -179,7 +180,10 @@ class AutoStructify(transforms.Transform):
                                  self.current_level)
         return self.state_machine.run_directive(
             'toctree',
-            options={'maxdepth': 1, 'numbered': numbered},
+            options={
+                'maxdepth': self.config['auto_toc_maxdepth'],
+                'numbered': numbered,
+            },
             content=['%s <%s>' % (k, v) for k, v in refs])
 
     def auto_inline_code(self, node):


### PR DESCRIPTION
This adds the 'auto_toc_maxdepth' config option (defaults to 1) that
will set the max depth for the auto-generated table of contents.