### PR TITLE
Fix inline math

### DIFF
--- a/recommonmark/states.py
+++ b/recommonmark/states.py
@@ -125,7 +125,7 @@ class DummyStateMachine(StateMachineWS):
                           self.node.line,
                           self.reporter)
         vec, _ = role_fn(name,
-                         rawtext=str(content),
+                         rawtext=str('`'+content+'`'),
                          text=str(content),
                          lineno=self.node.line,
                          inliner=self.memo.inliner,

--- a/recommonmark/transform.py
+++ b/recommonmark/transform.py
@@ -206,7 +206,7 @@ class AutoStructify(transforms.Transform):
         if not isinstance(content, nodes.Text):
             return None
         content = content.astext().strip()
-        if content.startswith('$') and content.endswith('$'):
+        if content.startswith('$') and content.endswith('$') and len(content) > 1:
             if not self.config['enable_inline_math']:
                 return None
             content = content[1:-1]


### PR DESCRIPTION
Hackily fixes #120 as it seems like `docutils` expects the backticks to still be on the string. Could also be fixed upstream by allowing the backticks to be missing.