### PR TITLE
Bugfix: External links to 'supported' files lose their file extension

### DIFF
--- a/recommonmark/parser.py
+++ b/recommonmark/parser.py
@@ -147,11 +147,19 @@ class CommonMarkParser(parsers.Parser):
         # Check destination is supported for cross-linking and remove extension
         destination = mdnode.destination
         _, ext = splitext(destination)
+
+        # Check if the destination starts with a url scheme, since internal and
+        # external links need to be handled differently.
+        url_check = urlparse(destination)
+        known_url_schemes = self.config.get('known_url_schemes')
+        if known_url_schemes:
+            scheme_known = url_check.scheme in known_url_schemes
+        else:
+            scheme_known = bool(url_check.scheme)
+
         # TODO check for other supported extensions, such as those specified in
         # the Sphinx conf.py file but how to access this information?
-        # TODO this should probably only remove the extension for local paths,
-        # i.e. not uri's starting with http or other external prefix.
-        if ext.replace('.', '') in self.supported:
+        if not scheme_known and ext.replace('.', '') in self.supported:
             destination = destination.replace(ext, '')
         ref_node['refuri'] = destination
         # TODO okay, so this is acutally not always the right line number, but
@@ -162,16 +170,9 @@ class CommonMarkParser(parsers.Parser):
             ref_node['title'] = mdnode.title
         next_node = ref_node
 
-        url_check = urlparse(destination)
         # If there's not a url scheme (e.g. 'https' for 'https:...' links),
         # or there is a scheme but it's not in the list of known_url_schemes,
         # then assume it's a cross-reference and pass it to Sphinx as an `:any:` ref.
-        known_url_schemes = self.config.get('known_url_schemes')
-        if known_url_schemes:
-            scheme_known = url_check.scheme in known_url_schemes
-        else:
-            scheme_known = bool(url_check.scheme)
-
         if not url_check.fragment and not scheme_known:
             wrap_node = addnodes.pending_xref(
                 reftarget=unquote(destination),

--- a/tests/sphinx_generic/index.md
+++ b/tests/sphinx_generic/index.md
@@ -17,6 +17,8 @@ This is a [pending ref](index)
 
 [example]: http://example.com/foobar "Example"
 
+External link to Markdown file: [Readme](https://github.com/readthedocs/recommonmark/blob/master/README.md).
+
 Foo
 
 ----

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -125,6 +125,12 @@ class GenericTests(SphinxIntegrationTests):
              '</a>'),
             output
         )
+        self.assertIn(
+            ('External link to Markdown file: '
+             '<a class="reference external" '
+             'href="https://github.com/readthedocs/recommonmark/blob/master/README.md">Readme</a>.'),
+            output
+        )
 
     def test_image(self):
         output = self.read_file('index.html')


### PR DESCRIPTION
Hi,

This PR fixes the erroneous handling of external links to 'supported' files.

Until now, the extension of _every_ supported type has been stripped.

Adding an additional check ("if not scheme_known") was sufficient to avoid doing this for external links.

**Example:**

A link to http://example.com/README.md will point to http://example.com/README without this fix, since 'md' is a supported type.

**Example 2:**

Simply linking to this project's README file is impossible at the moment: 
https://github.com/readthedocs/recommonmark/blob/master/README.md becomes https://github.com/readthedocs/recommonmark/blob/master/README, which of course doesn't exist.
