### PR TITLE
Set section level attribute

### DIFF
--- a/recommonmark/parser.py
+++ b/recommonmark/parser.py
@@ -85,7 +85,7 @@ class CommonMarkParser(parsers.Parser):
         title_node = nodes.title()
         title_node.line = mdnode.sourcepos[0][0]
 
-        new_section = nodes.section()
+        new_section = nodes.section(level=mdnode.level)
         new_section.line = mdnode.sourcepos[0][0]
         new_section.append(title_node)
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -35,9 +35,9 @@ class TestParsing(unittest.TestCase):
             """
             <?xml version="1.0" ?>
             <document source="&lt;string&gt;">
-              <section ids="heading-1" names="heading\ 1">
+              <section ids="heading-1" level="1" names="heading\ 1">
                 <title>Heading 1</title>
-                <section ids="heading-2" names="heading\ 2">
+                <section ids="heading-2" level="2" names="heading\ 2">
                   <title>Heading 2</title>
                   <paragraph>Body</paragraph>
                 </section>
@@ -52,7 +52,7 @@ class TestParsing(unittest.TestCase):
             """
             <?xml version="1.0" ?>
             <document source="&lt;string&gt;">
-              <section ids="heading-foo" names="heading\ foo">
+              <section ids="heading-foo" level="1" names="heading\ foo">
                 <title>
                   Heading \n\
                   <emphasis>foo</emphasis>


### PR DESCRIPTION
This restores a feature (i.e. fixes a regression) that existed in recommonmark 0.4.0.