### PR TITLE
Run AutoStructify after Sphinx's Locale transform

### DIFF
--- a/recommonmark/transform.py
+++ b/recommonmark/transform.py
@@ -8,6 +8,7 @@ from docutils.statemachine import StringList
 from docutils.parsers.rst import Parser
 from docutils.utils import new_document
 from sphinx import addnodes
+from sphinx.transforms.i18n import Locale
 
 from .states import DummyStateMachine
 
@@ -35,8 +36,9 @@ class AutoStructify(transforms.Transform):
             self.reporter.warning(
                 'AutoStructify option "enable_auto_doc_ref" is deprecated')
 
-    # set to a high priority so it can be applied first for markdown docs
-    default_priority = 1
+    # This must run after Sphinx's Locale transform. Otherwise, translations of strings in reStructured Text will be
+    # parsed as Markdown.
+    default_priority = Locale.default_priority + 1
     suffix_set = set(['md', 'rst'])
 
     default_config = {


### PR DESCRIPTION
This is a better solution than https://github.com/readthedocs/recommonmark/pull/52

Note that you'd need to test on an unreleased version of commonmark.py to get this PR https://github.com/readthedocs/commonmark.py/pull/225 and you'd need to have already merged #187, as otherwise translations are broken for other reasons.